### PR TITLE
Fix/catch api limit errors

### DIFF
--- a/responsys/__init__.py
+++ b/responsys/__init__.py
@@ -1,4 +1,4 @@
 """Python client library for the Responsys Interact API"""
 
-__version__ = "0.2.4"
+__version__ = "0.2.4.ud1"
 __keywords__ = "responsys interact client api"

--- a/responsys/client.py
+++ b/responsys/client.py
@@ -115,7 +115,7 @@ class InteractClient(object):
             log.exception('Failed to connect to responsys service')
             raise ConnectError("Request to service timed out")
         except WebFault as web_fault:
-            fault_name = getattr(web_fault.fault, 'faultstring', '').strip()
+            fault_name = str(getattr(web_fault.fault, 'faultstring', '')).strip()
             error = str(web_fault.fault.detail)
 
             if fault_name == 'TableFault':

--- a/responsys/client.py
+++ b/responsys/client.py
@@ -115,7 +115,7 @@ class InteractClient(object):
             log.exception('Failed to connect to responsys service')
             raise ConnectError("Request to service timed out")
         except WebFault as web_fault:
-            fault_name = getattr(web_fault.fault, 'faultstring', None)
+            fault_name = getattr(web_fault.fault, 'faultstring', '').strip()
             error = str(web_fault.fault.detail)
 
             if fault_name == 'TableFault':

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     name=responsys.__name__,
     keywords=responsys.__keywords__,
     version=responsys.__version__,
-    url='https://github.com/jslang/responsys',
+    url='https://github.com/udemy/responsys',
     author='Jared Lang',
     description='Python client library for the Responsys Interact API',
     long_description=long_description,


### PR DESCRIPTION
@udemy/appsec-and-fraud 

- tested with dev creds and confirmed that stripping away the blank space around the fault string is all we need to do. 
- these are the kinds of API limit errors this will catch: https://app.datadoghq.com/logs?cols=core_host%2Ccore_service&event=AQAAAXFRIGcCnmT_IQAAAABBWEZSSUdxNE1SZGVQSUt2WUVBQQ&from_ts=1586190180612&index=&live=true&messageDisplay=inline&query=status%3Awarn+++%22responsys_trigger_event.exception%22&spanID=13795673361556812288&stream_sort=desc&to_ts=1586204580612&traceID=7229075646281307216
- I'll open separate django PR to use this forked repo


Jira: https://udemyjira.atlassian.net/browse/WA-163