### PR TITLE
Update how version is referenced in setup

### DIFF
--- a/responsys/__init__.py
+++ b/responsys/__init__.py
@@ -1,4 +1,3 @@
 """Python client library for the Responsys Interact API"""
 
-__version__ = "0.2.4.ud1"
 __keywords__ = "responsys interact client api"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ tests_require = (
 setup(
     name=responsys.__name__,
     keywords=responsys.__keywords__,
-    version=responsys.__version__,
+    version="0.2.4.ud1",
     url='https://github.com/udemy/responsys',
     author='Jared Lang',
     description='Python client library for the Responsys Interact API',


### PR DESCRIPTION
@eric-at-udemy @bahattintozyilmaz 

Poetry was running into the following error: `Unable to retrieve the package version`. Setup was not able to read from __init__ file while being loaded. I believe this was due to `install_requires` requirements that appear in the setup file and are used in the Responsys code. 

I've tested this locally -- pointing the responsys dependency in `pyproject.toml` to `responsys = { path = "/Users/erinturner/Code/responsys" }` and running `poetry lock`. It runs successfully with this update. 